### PR TITLE
Called 'ct_cacheVideo' inside 'ct_mediaLoaded'

### DIFF
--- a/page/page.js
+++ b/page/page.js
@@ -955,6 +955,7 @@ function ct_mediaLoaded () {
 		md_totalTime = yt_video.meta.length;
 		md_curTime = parseInt(new URL(window.location.href).searchParams.get("t")) || 0;
 		ui_updateTimelineProgress();
+		ct_cacheVideo(yt_video);
 		md_updateStreams(); // Fires ct_mediaReady or ct_mediaError eventually
 	}
 }


### PR DESCRIPTION
Closes #8 

I did what you mentioned in the issue. Called `ct_cacheVideo`inside `ct_mediaLoaded` in order to cache and play simultaneously. 

Sorry for the commit message. I wasnt sure how to name it so if it is bad you can change it. 